### PR TITLE
OS.networkInterfaces() has introduced in UXP-5.6

### DIFF
--- a/src/pages/uxp/reference-js/Modules/os/OS.md
+++ b/src/pages/uxp/reference-js/Modules/os/OS.md
@@ -33,3 +33,22 @@ Gets the platform architecture we are running on (eg. "x32, x64, x86_64 etc")
 
 **Returns**: `string` - the string representing the architecture  
 
+## networkInterfaces()
+Gets the network interfaces that have been assigned a network address
+
+**Returns**: `Object` - an object containing network interfaces that have been assigned a network address. Each key on the returned object identifies a network interface. The associated value is an object that has the following properties.
+
+| Name | Type | Description |
+| --- | --- | --- |
+| mac | `string` | The MAC address of the network interface |
+
+Note that networkInterfaces() is available only for 1P plugins.
+
+**Example**
+```
+const os = require("torq-native").os;
+let networkInterfaces = os.networkInterfaces();
+for (let name in networkInterfaces) {
+  console.log(`NetworkInterface name=[${name}], MAC address=[${interfaces[name].mac}`);
+}
+```


### PR DESCRIPTION
OS.networkInterfaces() has introduced in UXP-5.6.

## Description

API description for OS.networkInterfaces().

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
