### PR TITLE
Corrected API documentation for Persistent File Storage -> Entry.copyTo()

### DIFF
--- a/src/pages/uxp/reference-js/Modules/uxp/Persistent File Storage/Entry.md
+++ b/src/pages/uxp/reference-js/Modules/uxp/Persistent File Storage/Entry.md
@@ -143,7 +143,7 @@ Copies this entry to the specified `folder`.
 | folder | `Folder` |  | the folder to which to copy this entry |
 | options | `*` |  |  |
 | [options.overwrite] | `boolean` | `false` | if `true`, allows overwriting existing entries |
-| [options.allowFolderCopy] | `boolean` | <code>false</code> if `true`, allows copying the folder |
+| [options.allowFolderCopy] | `boolean` | `false` if `true`, allows copying the folder |
 
 **Example**  
 ```js

--- a/src/pages/uxp/reference-js/Modules/uxp/Persistent File Storage/Entry.md
+++ b/src/pages/uxp/reference-js/Modules/uxp/Persistent File Storage/Entry.md
@@ -143,6 +143,7 @@ Copies this entry to the specified `folder`.
 | folder | `Folder` |  | the folder to which to copy this entry |
 | options | `*` |  |  |
 | [options.overwrite] | `boolean` | `false` | if `true`, allows overwriting existing entries |
+| [options.allowFolderCopy] | `boolean` | <code>false</code> if `true`, allows copying the folder |
 
 **Example**  
 ```js
@@ -154,7 +155,7 @@ await someFile.copyTo(someFolder, {overwrite: true});
 ```
 **Example**  
 ```js
-await someFolder.copyTo(anotherFolder, {overwrite: true});
+await someFolder.copyTo(anotherFolder, {overwrite: true, allowFolderCopy: true});
 ```
 
 

--- a/src/pages/uxp/reference-js/Modules/uxp/Persistent File Storage/Entry.md
+++ b/src/pages/uxp/reference-js/Modules/uxp/Persistent File Storage/Entry.md
@@ -143,7 +143,7 @@ Copies this entry to the specified `folder`.
 | folder | `Folder` |  | the folder to which to copy this entry |
 | options | `*` |  |  |
 | [options.overwrite] | `boolean` | `false` | if `true`, allows overwriting existing entries |
-| [options.allowFolderCopy] | `boolean` | `false` if `true`, allows copying the folder |
+| [options.allowFolderCopy] | `boolean` | `false` | if `true`, allows copying the folder |
 
 **Example**  
 ```js


### PR DESCRIPTION
The second argument 'option' should have `allowFolderCopy` set to `true` when an attempt to copy the folder is made. The documentation for this is missing at https://developer.adobe.com/xd/uxp/uxp/reference-js/Modules/uxp/Persistent%20File%20Storage/Entry/.

## Description

Updating the API documentation for Persistent File Storage -> Entry.copyTo()

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Tracked internally as a Jira ticket.

## Motivation and Context

Folder copy is not allowed by default. The developer using this API will see a 'Plugin Error: Source is a Folder - Folder copy is not allowed by default' if they dont set the option argument correctly.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
