### PR TITLE
Fixing Webview Gatsby parsing errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The side navigation panel in the devsite is generated from the `reference-*.js` 
     * `src/pages/uxp/index.md`
     * `reference-spectrum/index.md`
     * `reference-js/index.md`
+    * `HTMLWebViewElement.md`
 4. Maintain a consistent order for the API information. 
     * Since
     * Description
@@ -73,9 +74,8 @@ The side navigation panel in the devsite is generated from the `reference-*.js` 
 6. Other fixes done manually in this repo which should be fixed in sourve files:
     * Backticks in H1 titles in source files.
     * Extra dots. Example `Promise.<void>` in SecureStorage.md
+    * `<br>` tags without a closing `</br>`
 7. Index pages (coming from index.md) show links ordered alphabetically. For example: https://developer.adobe.com/photoshop/uxp/2022/uxp/reference-js/Global%20Members/HTML%20DOM/. But the left side panel (coming from reference-*.js) is not necessarily alphabetical. Make them consistent.
-
-
 
 
 

--- a/src/pages/uxp/known-issues.md
+++ b/src/pages/uxp/known-issues.md
@@ -41,7 +41,7 @@ The following issues are known. Please check this page with future updates, as k
 * The numeric `sp-textfield` can trigger numeric validation errors, even when the entered value would seem to be correct. This will be addressed in a future release. The limitation on valid ranges is an issue with numeric fields in Photoshop in general and is a separate issue. (PS-57698)
 
 ## WebView
-* Mouuse/Keyboard events within Webview doesn't work in XD v55 and Win 10 due to a [Microsoft issue](https://github.com/microsoft/microsoft-ui-xaml/issues/6427). Fix for this is in progress.
+* Mouse/Keyboard events within Webview doesn't work in XD v55 and Win 10 due to a [Microsoft issue](https://github.com/microsoft/microsoft-ui-xaml/issues/6427). Fix for this is in progress.
 
 ## Events
 

--- a/src/pages/uxp/reference-js/Global Members/HTML Elements/HTMLWebViewElement.md
+++ b/src/pages/uxp/reference-js/Global Members/HTML Elements/HTMLWebViewElement.md
@@ -6,7 +6,7 @@
 
 | Name | Type | Description |
 | --- | --- | --- |
-| uxpallowinspector | `boolean` | Enable Developer tools for WebView <br>&nbsp;&nbsp;e.g., \<webview src="https://www.adobe.com" uxpallowinspector="true"\>\<\/webview\> |
+| uxpallowinspector | `boolean` | Enable Developer tools for WebView e.g., `<webview src="https://www.adobe.com" uxpallowinspector="true"></webview>` |
 
 
 
@@ -310,27 +310,25 @@ Plugin can receive the messages from WebView via 'message' event.
 
 [Plugin]
 - send messages to the content in the WebView
-<br>&nbsp;&nbsp;HTMLWebViewElement.postMessage(msg)
+`HTMLWebViewElement.postMessage(msg)`
 - receive messages from the content in the WebView
-<br>&nbsp;&nbsp;window.addEventListener("message", (e) => { ... })
-<br>&nbsp;&nbsp;
-     e: Event {
-<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; origin: URL of the content
-<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; source: window.uxpHost,
-<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; data: message
-<br>&nbsp;&nbsp;&nbsp;}
+`window.addEventListener("message", (e) => { ... })`
+<br></br>&nbsp;&nbsp;e: Event {
+<br></br>&nbsp;&nbsp;&nbsp;&nbsp;origin: URL of the content,
+<br></br>&nbsp;&nbsp;&nbsp;&nbsp;source: window.uxpHost,
+<br></br>&nbsp;&nbsp;&nbsp;&nbsp;data: message
+<br></br>&nbsp;&nbsp;}
 
 [Content in the WebView]
 - send messages to plugin
-<br>&nbsp;&nbsp;window.uxpHost.postMessage(message)
+`window.uxpHost.postMessage(message)`
 - receive messages from plugin
-<br>&nbsp;&nbsp;window.addEventListener("message", (e) => { ... })
-<br>&nbsp;&nbsp;
-     e: Event {
-<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; origin: plugin id,
-<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; source: WebView element
-<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; data: message
-<br>&nbsp;&nbsp;&nbsp;}
+`window.addEventListener("message", (e) => { ... })`
+<br></br>&nbsp;&nbsp;e: Event {
+<br></br>&nbsp;&nbsp;&nbsp;&nbsp;origin: plugin id,
+<br></br>&nbsp;&nbsp;&nbsp;&nbsp;source: WebView element,
+<br></br>&nbsp;&nbsp;&nbsp;&nbsp;data: message
+<br></br>&nbsp;&nbsp;}
 
 
 | Param | Type | Description |
@@ -706,6 +704,3 @@ Scrolls the element to the new x and y positions. If options object is used with
 | Param | Type |
 | --- | --- |
 | event | `*` | 
-
-
-  

--- a/src/pages/uxp/reference-js/Modules/uxp/Persistent File Storage/FileSystem.md
+++ b/src/pages/uxp/reference-js/Modules/uxp/Persistent File Storage/FileSystem.md
@@ -3,7 +3,7 @@
 # require('uxp').storage.FileSystem
 
 UXP Provides Node.js style file system API, FSAPI.
-Unlike [Entry](#module-storage-entry) based [File](#module-storage-file) or [Folder](#module-storage-folder) classes,
+Unlike [Entry](./Entry/) based [File](./File/) or [Folder](./Folder/) classes,
 these methods can directly access a local file or folder with path or file descriptor.
 The starting point of a path in the native filesystem depends on the scheme.
 UXP supports plugin-specific storage schemes, such as "plugin:", "plugin-data:",

--- a/src/pages/uxp/reference-js/Modules/uxp/Plugin Manager/Plugin.md
+++ b/src/pages/uxp/reference-js/Modules/uxp/Plugin Manager/Plugin.md
@@ -50,7 +50,7 @@ Get plugin enabled/disabled state
 ## showPanel(panelId)
 Show panel with the given ID. This api may be routed to the host app which can chose to disallow it. Used for commmunicating with other plugins (IPC : Inter Plugin Communication)
 
-Note: There is API to hide a panel, panels can be shown but can not be hid.
+Note: There isn't an API to hide a panel. Panels can be shown but can not be hid.
 
 **Returns**: `Promise`  
 


### PR DESCRIPTION
HTMLWebViewElement.md 

## Description

Fix format for HTMLWebViewElement.md for failing Gatsby errors.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
