### PR TITLE
Removed redundant `uxp` property.

### DIFF
--- a/src/pages/uxp/reference-js/Modules/uxp/Persistent File Storage/localFileSystem.md
+++ b/src/pages/uxp/reference-js/Modules/uxp/Persistent File Storage/localFileSystem.md
@@ -4,5 +4,5 @@ jsDoc: true
 
 <a name="module-storage-localfilesystem" id="module-storage-localfilesystem"></a>
 
-# require('uxp').uxp.storage.localFileSystem : `LocalFileSystemProvider`
+# require('uxp').storage.localFileSystem : `LocalFileSystemProvider`
 


### PR DESCRIPTION
## Description

Docs contained an extraneous `uxp` property. 

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
